### PR TITLE
[Hotfix] Release v2.2.2

### DIFF
--- a/MaterialDialogLibrary/src/main/java/dev/shreyaspatil/MaterialDialog/AbstractDialog.java
+++ b/MaterialDialogLibrary/src/main/java/dev/shreyaspatil/MaterialDialog/AbstractDialog.java
@@ -6,7 +6,6 @@ import android.content.res.ColorStateList;
 import android.content.res.Configuration;
 import android.content.res.TypedArray;
 import android.os.Build;
-import android.text.Html;
 import android.text.Spanned;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -26,7 +25,8 @@ import dev.shreyaspatil.MaterialDialog.interfaces.OnCancelListener;
 import dev.shreyaspatil.MaterialDialog.interfaces.OnDismissListener;
 import dev.shreyaspatil.MaterialDialog.interfaces.OnShowListener;
 import dev.shreyaspatil.MaterialDialog.model.DialogButton;
-import dev.shreyaspatil.MaterialDialog.model.DialogText;
+import dev.shreyaspatil.MaterialDialog.model.DialogMessage;
+import dev.shreyaspatil.MaterialDialog.model.DialogTitle;
 import dev.shreyaspatil.MaterialDialog.model.TextAlignment;
 
 @SuppressWarnings("unused")
@@ -40,8 +40,8 @@ public abstract class AbstractDialog implements DialogInterface {
 
     protected Dialog mDialog;
     protected Activity mActivity;
-    protected DialogText title;
-    protected DialogText message;
+    protected DialogTitle title;
+    protected DialogMessage message;
     protected boolean mCancelable;
     protected DialogButton mPositiveButton;
     protected DialogButton mNegativeButton;
@@ -57,8 +57,8 @@ public abstract class AbstractDialog implements DialogInterface {
     protected OnShowListener mOnShowListener;
 
     protected AbstractDialog(@NonNull Activity mActivity,
-                             @NonNull DialogText title,
-                             @NonNull DialogText message,
+                             @NonNull DialogTitle title,
+                             @NonNull DialogMessage message,
                              boolean mCancelable,
                              @NonNull DialogButton mPositiveButton,
                              @NonNull DialogButton mNegativeButton,
@@ -98,13 +98,8 @@ public abstract class AbstractDialog implements DialogInterface {
         // Set Message
         if (message != null) {
             mMessageView.setVisibility(View.VISIBLE);
-            Spanned spannedMessage = null;
-            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-                spannedMessage = Html.fromHtml(message.getText(), Html.FROM_HTML_MODE_COMPACT);
-            } else {
-                spannedMessage = Html.fromHtml(message.getText());
-            }
-            mMessageView.setText(spannedMessage);
+
+            mMessageView.setText(message.getText());
             mMessageView.setTextAlignment(message.getTextAlignment().getAlignment());
         } else {
             mMessageView.setVisibility(View.GONE);
@@ -349,8 +344,8 @@ public abstract class AbstractDialog implements DialogInterface {
      */
     public static abstract class Builder<D extends AbstractDialog> {
         protected final Activity activity;
-        protected DialogText title;
-        protected DialogText message;
+        protected DialogTitle title;
+        protected DialogMessage message;
         protected boolean isCancelable;
         protected DialogButton positiveButton;
         protected DialogButton negativeButton;
@@ -380,12 +375,12 @@ public abstract class AbstractDialog implements DialogInterface {
          */
         @NonNull
         public Builder<D> setTitle(@NonNull String title, @NonNull TextAlignment alignment) {
-            this.title = new DialogText(title, alignment);
+            this.title = new DialogTitle(title, alignment);
             return this;
         }
 
         /**
-         * @param message Sets the Message of Material Dialog with the default alignment as center.
+         * @param message Sets the plain text Message of Material Dialog with the default alignment as center.
          * @return this, for chaining.
          */
         @NonNull
@@ -394,13 +389,33 @@ public abstract class AbstractDialog implements DialogInterface {
         }
 
         /**
-         * @param message   Sets the Message of Material Dialog.
+         * @param message   Sets the plain text Message of Material Dialog.
          * @param alignment Sets the Alignment for the message.
          * @return this, for chaining.
          */
         @NonNull
         public Builder<D> setMessage(@NonNull String message, @NonNull TextAlignment alignment) {
-            this.message = new DialogText(message, alignment);
+            this.message = DialogMessage.text(message, alignment);
+            return this;
+        }
+
+        /**
+         * @param message Sets the spanned text Message of Material Dialog with the default alignment as center.
+         * @return this, for chaining.
+         */
+        @NonNull
+        public Builder<D> setMessage(@NonNull Spanned message) {
+            return setMessage(message, TextAlignment.CENTER);
+        }
+
+        /**
+         * @param message   Sets the spanned text Message of Material Dialog.
+         * @param alignment Sets the Alignment for the message.
+         * @return this, for chaining.
+         */
+        @NonNull
+        public Builder<D> setMessage(@NonNull Spanned message, @NonNull TextAlignment alignment) {
+            this.message = DialogMessage.spanned(message, alignment);
             return this;
         }
 

--- a/MaterialDialogLibrary/src/main/java/dev/shreyaspatil/MaterialDialog/BottomSheetMaterialDialog.java
+++ b/MaterialDialogLibrary/src/main/java/dev/shreyaspatil/MaterialDialog/BottomSheetMaterialDialog.java
@@ -18,7 +18,8 @@ import androidx.annotation.RawRes;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 
 import dev.shreyaspatil.MaterialDialog.model.DialogButton;
-import dev.shreyaspatil.MaterialDialog.model.DialogText;
+import dev.shreyaspatil.MaterialDialog.model.DialogMessage;
+import dev.shreyaspatil.MaterialDialog.model.DialogTitle;
 
 /**
  * Creates BottomSheet Material Dialog with 2 buttons.
@@ -29,8 +30,8 @@ import dev.shreyaspatil.MaterialDialog.model.DialogText;
 public final class BottomSheetMaterialDialog extends AbstractDialog {
 
     private BottomSheetMaterialDialog(@NonNull final Activity mActivity,
-                                      @NonNull DialogText title,
-                                      @NonNull DialogText message,
+                                      @NonNull DialogTitle title,
+                                      @NonNull DialogMessage message,
                                       boolean mCancelable,
                                       @NonNull DialogButton mPositiveButton,
                                       @NonNull DialogButton mNegativeButton,

--- a/MaterialDialogLibrary/src/main/java/dev/shreyaspatil/MaterialDialog/MaterialDialog.java
+++ b/MaterialDialogLibrary/src/main/java/dev/shreyaspatil/MaterialDialog/MaterialDialog.java
@@ -9,7 +9,8 @@ import androidx.annotation.RawRes;
 import androidx.appcompat.app.AlertDialog;
 
 import dev.shreyaspatil.MaterialDialog.model.DialogButton;
-import dev.shreyaspatil.MaterialDialog.model.DialogText;
+import dev.shreyaspatil.MaterialDialog.model.DialogMessage;
+import dev.shreyaspatil.MaterialDialog.model.DialogTitle;
 
 /**
  * Creates a Material Dialog with 2 buttons.
@@ -20,8 +21,8 @@ import dev.shreyaspatil.MaterialDialog.model.DialogText;
 public final class MaterialDialog extends AbstractDialog {
 
     private MaterialDialog(@NonNull final Activity mActivity,
-                           @NonNull DialogText title,
-                           @NonNull DialogText message,
+                           @NonNull DialogTitle title,
+                           @NonNull DialogMessage message,
                            boolean mCancelable,
                            @NonNull DialogButton mPositiveButton,
                            @NonNull DialogButton mNegativeButton,

--- a/MaterialDialogLibrary/src/main/java/dev/shreyaspatil/MaterialDialog/model/DialogMessage.java
+++ b/MaterialDialogLibrary/src/main/java/dev/shreyaspatil/MaterialDialog/model/DialogMessage.java
@@ -1,0 +1,55 @@
+package dev.shreyaspatil.MaterialDialog.model;
+
+import android.text.Spanned;
+
+public abstract class DialogMessage<T extends CharSequence> {
+    private final TextAlignment textAlignment;
+
+    private DialogMessage(TextAlignment textAlignment) {
+        this.textAlignment = textAlignment;
+    }
+
+    public static SpannedMessage spanned(Spanned text, TextAlignment alignment) {
+        return new SpannedMessage(text, alignment);
+    }
+
+    public static TextMessage text(String text, TextAlignment alignment) {
+        return new TextMessage(text, alignment);
+    }
+
+    public TextAlignment getTextAlignment() {
+        return textAlignment;
+    }
+
+    public abstract T getText();
+
+    public static class SpannedMessage extends DialogMessage<Spanned> {
+
+        private final Spanned text;
+
+        SpannedMessage(Spanned text, TextAlignment textAlignment) {
+            super(textAlignment);
+            this.text = text;
+        }
+
+        @Override
+        public Spanned getText() {
+            return text;
+        }
+    }
+
+    public static class TextMessage extends DialogMessage<String> {
+
+        private final String text;
+
+        TextMessage(String text, TextAlignment textAlignment) {
+            super(textAlignment);
+            this.text = text;
+        }
+
+        @Override
+        public String getText() {
+            return text;
+        }
+    }
+}

--- a/MaterialDialogLibrary/src/main/java/dev/shreyaspatil/MaterialDialog/model/DialogTitle.java
+++ b/MaterialDialogLibrary/src/main/java/dev/shreyaspatil/MaterialDialog/model/DialogTitle.java
@@ -1,10 +1,10 @@
 package dev.shreyaspatil.MaterialDialog.model;
 
-public class DialogText {
+public class DialogTitle {
     private final String text;
     private final TextAlignment textAlignment;
 
-    public DialogText(String text, TextAlignment textAlignment) {
+    public DialogTitle(String text, TextAlignment textAlignment) {
         this.text = text;
         this.textAlignment = textAlignment;
     }

--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ If it's not provided in builder, `TextAlignment.CENTER` is considered by default
 
 ### HTML formatting for Message
 
-HTML span formatting is supported only for dialog's ***message***. While setting a message, you can directly provide formatted string as shown in following example.
+HTML spanned text is supported only for dialog's ***message***. While setting a message, you can directly provide `Spanned` instance as shown in following example.
 
 ```java
         MaterialDialog mDialog = new MaterialDialog.Builder(this)
-                .setMessage("<b>Lorem <i>Ipsum</i></b>. Click <a href=\"https://example.com\">here</a> for more information")
+                .setMessage(Html.fromText("<b>Lorem <i>Ipsum</i></b>. <br> Click <a href=\"https://example.com\">here</a> for more information"))
 ```
 
 <a name="showAnims"></a>
@@ -256,9 +256,7 @@ Prototype :
 Resource file should be passed to method. e.g. `R.raw.delete_anim`. 
 ```java
         MaterialButton mDialog = new MaterialDialog.Builder(this)
-                // Other Methods to create Dialog........               
-                .setAnimation(R.raw.delete_anim)                
-                //...
+                .setAnimation(R.raw.delete_anim)
 ```
 <a name="showAnimFile"></a>
 #### ii. Using `Asset` File

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
 
     // Material Dialog Library
-    implementation 'dev.shreyaspatil.MaterialDialog:MaterialDialog:2.2.1'
+    implementation 'dev.shreyaspatil.MaterialDialog:MaterialDialog:2.2.2'
 
     // Material Design Library
     implementation 'com.google.android.material:material:1.3.0'

--- a/app/src/main/java/dev/shreyaspatil/MaterialDialogExample/MainActivity.java
+++ b/app/src/main/java/dev/shreyaspatil/MaterialDialogExample/MainActivity.java
@@ -2,6 +2,7 @@ package dev.shreyaspatil.MaterialDialogExample;
 
 import android.annotation.SuppressLint;
 import android.os.Bundle;
+import android.text.Html;
 import android.view.View;
 import android.widget.Button;
 import android.widget.Toast;
@@ -36,7 +37,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         // Simple Material Dialog
         mSimpleDialog = new MaterialDialog.Builder(this)
                 .setTitle("Delete?", TextAlignment.START)
-                .setMessage("Are you sure want to <i>delete this file</i>?", TextAlignment.START)
+                .setMessage(Html.fromHtml("Are you sure want to <i>delete this file</i>?"), TextAlignment.START)
                 .setCancelable(false)
                 .setPositiveButton("Delete", R.drawable.ic_delete, new MaterialDialog.OnClickListener() {
                     @Override
@@ -57,7 +58,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         // Simple BottomSheet Material Dialog
         mSimpleBottomSheetDialog = new BottomSheetMaterialDialog.Builder(this)
                 .setTitle("Delete?", TextAlignment.CENTER)
-                .setMessage("Are you sure want to <i>delete this file</i>?", TextAlignment.CENTER)
+                .setMessage("Are you sure want to delete this file?", TextAlignment.CENTER)
                 .setCancelable(false)
                 .setPositiveButton("Delete", R.drawable.ic_delete, new BottomSheetMaterialDialog.OnClickListener() {
                     @Override
@@ -78,7 +79,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         // Animated Simple Material Dialog
         mAnimatedDialog = new MaterialDialog.Builder(this)
                 .setTitle("Delete?")
-                .setMessage("Are you sure want to <i>delete this file</i>?")
+                .setMessage("Are you sure want to delete this file?")
                 .setCancelable(false)
                 .setPositiveButton("Delete", R.drawable.ic_delete, new MaterialDialog.OnClickListener() {
                     @Override
@@ -100,7 +101,7 @@ public class MainActivity extends AppCompatActivity implements View.OnClickListe
         // Animated BottomSheet Material Dialog
         mAnimatedBottomSheetDialog = new BottomSheetMaterialDialog.Builder(this)
                 .setTitle("Delete?")
-                .setMessage("Are you sure want to <i>delete this file</i>?")
+                .setMessage("Are you sure want to delete this file?")
                 .setCancelable(false)
                 .setPositiveButton("Delete", R.drawable.ic_delete, new BottomSheetMaterialDialog.OnClickListener() {
                     @Override

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
 
-        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.1'
+        classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.2'
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,7 @@ android.enableJetifier=true
 # Maven Publish Details
 GROUP=dev.shreyaspatil.MaterialDialog
 POM_ARTIFACT_ID=MaterialDialog
-VERSION_NAME=2.2.0
+VERSION_NAME=2.2.2
 POM_NAME=MaterialDialog-Android
 POM_DESCRIPTION=Android Library to implement animated, beautiful, stylish Material Dialog in android apps easily.
 POM_INCEPTION_YEAR=2021


### PR DESCRIPTION
# Summary

Added support for plain text (i.e. `String`) as well as `Spanned` text for dialog's message.

_Earlier, in `v2.2.1`, there was only support for spanned formatted text for the message which was not generic. This fix now provides both the available configuration as per the need of the developer and use case._

For example,

- ***To set plain text message for dialog:***

```java
    .setMessage("Lorem Ipsum") 
```

- ***To Spanned text message for dialog:***

```java
    .setMessage(Html.fromText("<b>Lorem <i>Ipsum</i></b>")) 
```
---

Resolves: #49 